### PR TITLE
08 patch /api/articles/:article_id

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -261,6 +261,22 @@ describe("/api/articles/:article_id", () => {
                 expect(body.msg).toBe("Not found - no article of this ID in database");
             });
         });
+        test("Returns 'Status: 400' and relevant error message if no 'inc_votes' property on request body", () => {
+            return request(app).patch('/api/articles/1')
+            .send({ change_votes: 2 })
+            .expect(400)
+            .then(({ body }) => {
+                expect(body.msg).toBe("Bad request - body must have 'inc_votes' property of 'number' data type");
+            });
+        });
+        test("Returns 'Status: 400' and relevant error message if 'inc_votes' property is of incorrect data type", () => {
+            return request(app).patch('/api/articles/1')
+            .send({ inc_votes: "abc" })
+            .expect(400)
+            .then(({ body }) => {
+                expect(body.msg).toBe("Bad request - body must have 'inc_votes' property of 'number' data type");
+            });
+        });
     });
 });
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -192,6 +192,25 @@ describe("/api/articles/:article_id", () => {
             });
         });
     });
+    describe("PATCH", () => {
+        test("Returns 'Status: 204' with empty object if sent empty request body", () => {
+            return request(app).patch('/api/articles/1')
+            .send()
+            .expect(204)
+            .then(({ body }) => {
+                expect(body).toEqual({})
+            });
+        });
+        test("Returns 'Status: 200' with an article object", () => {
+            return request(app).patch('/api/articles/1')
+            .send({ inc_votes: 1 })
+            .expect(200)
+            .then(({ body }) => {
+                expect(typeof body.updatedArticle).toBe("object");
+                expect(Array.isArray(body.updatedArticle)).toBe(false)
+            });
+        });
+    });
 });
 
 describe("/api/articles/:article_id/comments", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -254,7 +254,7 @@ describe("/api/articles/:article_id", () => {
             .send({ change_votes: 2 })
             .expect(400)
             .then(({ body }) => {
-                expect(body.msg).toBe("Bad request - body must have 'inc_votes' property of 'number' data type");
+                expect(body.msg).toBe("Bad request");
             });
         });
         test("Returns 'Status: 400' and relevant error message if 'inc_votes' property is of incorrect data type", () => {
@@ -262,7 +262,7 @@ describe("/api/articles/:article_id", () => {
             .send({ inc_votes: "abc" })
             .expect(400)
             .then(({ body }) => {
-                expect(body.msg).toBe("Bad request - body must have 'inc_votes' property of 'number' data type");
+                expect(body.msg).toBe("Bad request");
             });
         });
     });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -318,12 +318,12 @@ describe("/api/articles/:article_id/comments", () => {
             return request(app).post('/api/articles/1/comments')
             .send({
                 body: "Mitch is cool",
-                username: "Sian"
+                username: "rogersop"
               })
             .expect(201)
             .then(({ body }) => {
                 expect(body.commentPosted).toHaveProperty("article_id", 1);
-                expect(body.commentPosted).toHaveProperty("author", "butter_bridge");
+                expect(body.commentPosted).toHaveProperty("author", "rogersop");
                 expect(body.commentPosted).toHaveProperty("body", "Mitch is cool");
                 expect(body.commentPosted).toHaveProperty("comment_id", 19);
                 expect(body.commentPosted).toHaveProperty("created_at");
@@ -334,7 +334,7 @@ describe("/api/articles/:article_id/comments", () => {
             return request(app).post('/api/articles/1/comments')
             .send({
                 body: "Mitch is cool",
-                username: "Sian"
+                username: "rogersop"
               })
             .expect(201)
             .then(() => {
@@ -350,7 +350,7 @@ describe("/api/articles/:article_id/comments", () => {
             return request(app).post('/api/articles/abc/comments')
             .send({
                 body: "Mitch is cool",
-                username: "Sian"
+                username: "rogersop"
               })
             .expect(400)
             .then(({ body }) => {
@@ -361,7 +361,7 @@ describe("/api/articles/:article_id/comments", () => {
             return request(app).post('/api/articles/392/comments')
             .send({
                 body: "Mitch is cool",
-                username: "Sian"
+                username: "rogersop"
               })
             .expect(404)
             .then(({ body }) => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -210,6 +210,23 @@ describe("/api/articles/:article_id", () => {
                 expect(Array.isArray(body.updatedArticle)).toBe(false)
             });
         });
+        test("Returned correct article object for ID with expected keys", () => {
+            return request(app).patch('/api/articles/1')
+            .send({ inc_votes: 1 })
+            .expect(200)
+            .then(({ body }) => {
+                const updatedArticle = body.updatedArticle;
+                console.log(updatedArticle)
+                expect(updatedArticle).toHaveProperty("article_id", 1)
+                expect(updatedArticle).toHaveProperty("title")
+                expect(updatedArticle).toHaveProperty("topic")
+                expect(updatedArticle).toHaveProperty("author")
+                expect(updatedArticle).toHaveProperty("body")
+                expect(updatedArticle).toHaveProperty("created_at")
+                expect(updatedArticle).toHaveProperty("votes")
+                expect(updatedArticle).toHaveProperty("article_img_url")
+            });
+        });
     });
 });
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -243,8 +243,24 @@ describe("/api/articles/:article_id", () => {
             .then(({rows}) => {
                 expect(rows[0].article_id).toBe(1);
                 expect(rows[0].votes).toBe(102);
-            })
-        })
+            });
+        });
+        test("Returns 'Status: 400' and relevant error message if article ID is of incorrect data type", () => {
+            return request(app).patch('/api/articles/abc')
+            .send({ inc_votes: 2 })
+            .expect(400)
+            .then(({ body }) => {
+                expect(body.msg).toBe("Bad request - invalid data type for article ID");
+            });
+        });
+        test("Returns 'Status: 404' and relevant error message if article ID does not exist in database", () => {
+            return request(app).patch('/api/articles/392')
+            .send({ inc_votes: 2 })
+            .expect(404)
+            .then(({ body }) => {
+                expect(body.msg).toBe("Not found - no article of this ID in database");
+            });
+        });
     });
 });
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -207,13 +207,12 @@ describe("/api/articles/:article_id", () => {
                 expect(Array.isArray(body.updatedArticle)).toBe(false)
             });
         });
-        test("Returned correct article object for ID with expected keys", () => {
+        test("Returns correct article object for ID with expected keys", () => {
             return request(app).patch('/api/articles/1')
             .send({ inc_votes: 1 })
             .expect(200)
             .then(({ body }) => {
                 const updatedArticle = body.updatedArticle;
-                console.log(updatedArticle)
                 expect(updatedArticle).toHaveProperty("article_id", 1)
                 expect(updatedArticle).toHaveProperty("title")
                 expect(updatedArticle).toHaveProperty("topic")
@@ -224,6 +223,28 @@ describe("/api/articles/:article_id", () => {
                 expect(updatedArticle).toHaveProperty("article_img_url")
             });
         });
+        test("Returns article object with 'votes' key updated by correct amount, including by negative numbers", () => {
+            return request(app).patch('/api/articles/1')
+            .send({ inc_votes: -20 })
+            .expect(200)
+            .then(({ body }) => {
+                const updatedArticle = body.updatedArticle;
+                expect(updatedArticle).toHaveProperty("article_id", 1)
+                expect(updatedArticle).toHaveProperty("votes", 80)
+            });
+        });
+        test("Updates to 'votes' column of the article are reflected in the articles database", () => {
+            return request(app).patch('/api/articles/1')
+            .send({ inc_votes: 2 })
+            .expect(200)
+            .then(() => {
+                return db.query('SELECT * FROM articles ORDER BY article_id;')
+            })
+            .then(({rows}) => {
+                expect(rows[0].article_id).toBe(1);
+                expect(rows[0].votes).toBe(102);
+            })
+        })
     });
 });
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -233,18 +233,6 @@ describe("/api/articles/:article_id", () => {
                 expect(updatedArticle).toHaveProperty("votes", 80)
             });
         });
-        test("Updates to 'votes' column of the article are reflected in the articles database", () => {
-            return request(app).patch('/api/articles/1')
-            .send({ inc_votes: 2 })
-            .expect(200)
-            .then(() => {
-                return db.query('SELECT * FROM articles ORDER BY article_id;')
-            })
-            .then(({rows}) => {
-                expect(rows[0].article_id).toBe(1);
-                expect(rows[0].votes).toBe(102);
-            });
-        });
         test("Returns 'Status: 400' and relevant error message if article ID is of incorrect data type", () => {
             return request(app).patch('/api/articles/abc')
             .send({ inc_votes: 2 })

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -190,12 +190,12 @@ describe("/api/articles/:article_id", () => {
         });
     });
     describe("PATCH", () => {
-        test("Returns 'Status: 204' with empty object if sent empty request body", () => {
+        test("Returns 'Status: 400' with 'Bad request' error message if sent empty request body", () => {
             return request(app).patch('/api/articles/1')
             .send()
-            .expect(204)
+            .expect(400)
             .then(({ body }) => {
-                expect(body).toEqual({})
+                expect(body.msg).toBe("Bad request")
             });
         });
         test("Returns 'Status: 200' with an article object", () => {
@@ -249,7 +249,7 @@ describe("/api/articles/:article_id", () => {
                 expect(body.msg).toBe("Not found - no article of this ID in database");
             });
         });
-        test("Returns 'Status: 400' and relevant error message if no 'inc_votes' property on request body", () => {
+        test("Returns 'Status: 400' and 'Bad request' error message if no 'inc_votes' property on request body", () => {
             return request(app).patch('/api/articles/1')
             .send({ change_votes: 2 })
             .expect(400)
@@ -257,7 +257,7 @@ describe("/api/articles/:article_id", () => {
                 expect(body.msg).toBe("Bad request");
             });
         });
-        test("Returns 'Status: 400' and relevant error message if 'inc_votes' property is of incorrect data type", () => {
+        test("Returns 'Status: 400' and 'Bad request' error message if 'inc_votes' property is of incorrect data type", () => {
             return request(app).patch('/api/articles/1')
             .send({ inc_votes: "abc" })
             .expect(400)

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -179,7 +179,7 @@ describe("/api/articles/:article_id", () => {
         test("Returns 'Status: 400' and relevant error message if article ID is of incorrect data type", () => {
             return request(app).get('/api/articles/abc').expect(400)
             .then(({ body }) => {
-                expect(body.msg).toBe("Bad request - invalid data type for article ID");
+                expect(body.msg).toBe("Bad request - invalid data type");
             });
         });
         test("Returns 'Status: 404' and relevant error message if article ID does not exist in database", () => {
@@ -238,7 +238,7 @@ describe("/api/articles/:article_id", () => {
             .send({ inc_votes: 2 })
             .expect(400)
             .then(({ body }) => {
-                expect(body.msg).toBe("Bad request - invalid data type for article ID");
+                expect(body.msg).toBe("Bad request - invalid data type");
             });
         });
         test("Returns 'Status: 404' and relevant error message if article ID does not exist in database", () => {
@@ -262,7 +262,7 @@ describe("/api/articles/:article_id", () => {
             .send({ inc_votes: "abc" })
             .expect(400)
             .then(({ body }) => {
-                expect(body.msg).toBe("Bad request");
+                expect(body.msg).toBe("Bad request - invalid data type");
             });
         });
     });
@@ -329,7 +329,7 @@ describe("/api/articles/:article_id/comments", () => {
         test("Returns 'Status: 400' and relevant error message if article ID is of incorrect data type", () => {
             return request(app).get('/api/articles/abc/comments').expect(400)
             .then(({ body }) => {
-                expect(body.msg).toBe("Bad request - invalid data type for article ID");
+                expect(body.msg).toBe("Bad request - invalid data type");
             });
         });
         test("Returns 'Status: 404' and relevant error message if article ID does not exist in database", () => {
@@ -395,7 +395,7 @@ describe("/api/articles/:article_id/comments", () => {
               })
             .expect(400)
             .then(({ body }) => {
-                expect(body.msg).toBe("Bad request - invalid data type for article ID");
+                expect(body.msg).toBe("Bad request - invalid data type");
             });
         });
         test("Returns 'Status: 404' and relevant error message if article ID does not exist in database", () => {

--- a/app/app.js
+++ b/app/app.js
@@ -1,7 +1,9 @@
 const express = require('express');
-const { getTopics, getArticles, getArticleById, getComments } = require('./controllers.js');
+const { getTopics, getArticles, getArticleById, getComments, updateArticle } = require('./controllers.js');
 
 const app = express();
+
+app.use(express.json());
 
 app.get('/api/topics', getTopics);
 
@@ -10,6 +12,10 @@ app.get('/api/articles', getArticles);
 app.get('/api/articles/:article_id', getArticleById);
 
 app.get('/api/articles/:article_id/comments', getComments);
+
+
+
+app.patch('/api/articles/:article_id', updateArticle);
 
 app.use((request, response, next) => {
     response.status(404).send({ msg: "Not found - this path does not exist" })

--- a/app/app.js
+++ b/app/app.js
@@ -32,7 +32,7 @@ app.use((error, request, response, next) => {
 
 app.use((error, request, response, next) => {
     if (error.code === '22P02') {
-        response.status(400).send({ msg: "Bad request - invalid data type for article ID" })
+        response.status(400).send({ msg: "Bad request - invalid data type" })
     }
     else {
         next(error)

--- a/app/controllers.js
+++ b/app/controllers.js
@@ -62,6 +62,9 @@ const updateArticle = (request, response, next) => {
         updateVotes(body, article_id).then((article) => {
             response.status(200).send({ updatedArticle: article });
         })
+        .catch((error) => {
+            next(error)
+        })
     }
     else {
         response.status(204).send();

--- a/app/controllers.js
+++ b/app/controllers.js
@@ -58,17 +58,12 @@ const updateArticle = (request, response, next) => {
     const { body } = request;
     const { article_id } = request.params;
 
-    if (Object.keys(body).length > 0) {
         updateVotes(body, article_id).then((article) => {
             response.status(200).send({ updatedArticle: article });
         })
         .catch((error) => {
             next(error)
-        })
-    }
-    else {
-        response.status(204).send();
-    }
+        });
 };
 
 module.exports = { getTopics, getArticles, getArticleById, getComments, postComment, updateArticle };

--- a/app/controllers.js
+++ b/app/controllers.js
@@ -37,4 +37,16 @@ const getComments = (request, response, next) => {
     })
 };
 
-module.exports = { getTopics, getArticles, getArticleById, getComments };
+const updateArticle = (request, response, next) => {
+    const { body } = request;
+    const { article_id } = request.params;
+
+    if (Object.keys(body).length > 0) {
+            response.status(200).send({ updatedArticle: {} });
+    }
+    else {
+        response.status(204).send();
+    }
+};
+
+module.exports = { getTopics, getArticles, getArticleById, getComments, updateArticle };

--- a/app/controllers.js
+++ b/app/controllers.js
@@ -1,4 +1,4 @@
-const { fetchTopics, fetchArticles, fetchArticleById, fetchCommentsById } = require('./models.js')
+const { fetchTopics, fetchArticles, fetchArticleById, fetchCommentsById, updateVotes } = require('./models.js')
 
 const getTopics = (request, response, next) => {
     fetchTopics().then((topics) => {
@@ -42,7 +42,9 @@ const updateArticle = (request, response, next) => {
     const { article_id } = request.params;
 
     if (Object.keys(body).length > 0) {
-            response.status(200).send({ updatedArticle: {} });
+        updateVotes(body, article_id).then((article) => {
+            response.status(200).send({ updatedArticle: article });
+        })
     }
     else {
         response.status(204).send();

--- a/app/models.js
+++ b/app/models.js
@@ -44,4 +44,21 @@ const fetchCommentsById = (article_id) => {
     });
 };
 
-module.exports = { fetchTopics, fetchArticles, fetchArticleById, fetchCommentsById };
+const updateVotes = (body, article_id) => {
+     return db.query(`SELECT votes FROM articles WHERE article_id = $1`, [article_id])
+        .then(({ rows }) => {
+            let newVoteTotal = rows[0].votes + body.inc_votes;
+        
+            let sqlUpdateVotesQuery = `UPDATE articles
+                                        SET votes = $1
+                                        WHERE article_id = $2
+                                        RETURNING *`
+            
+            return db.query(sqlUpdateVotesQuery, [newVoteTotal, article_id])
+        })
+        .then(({ rows }) => {
+        return rows[0];
+    });
+};
+
+module.exports = { fetchTopics, fetchArticles, fetchArticleById, fetchCommentsById, updateVotes };

--- a/app/models.js
+++ b/app/models.js
@@ -66,7 +66,7 @@ const updateVotes = (body, article_id) => {
     return fetchArticleById(article_id)
         .then(() => {
             if (!body.inc_votes || typeof body.inc_votes !== "number") {
-                return Promise.reject({ status: 400, msg: "Bad request - body must have 'inc_votes' property of 'number' data type" })
+                return Promise.reject({ status: 400, msg: "Bad request" })
             }
 
             let sqlUpdateVotesQuery = `UPDATE articles

--- a/app/models.js
+++ b/app/models.js
@@ -68,6 +68,9 @@ const updateVotes = (body, article_id) => {
             return db.query(`SELECT votes FROM articles WHERE article_id = $1`, [article_id])
         })
         .then(({ rows }) => {
+            if (!body.inc_votes || typeof body.inc_votes !== "number") {
+                return Promise.reject({ status: 400, msg: "Bad request - body must have 'inc_votes' property of 'number' data type" })
+            }
             let newVoteTotal = rows[0].votes + body.inc_votes;
 
             let sqlUpdateVotesQuery = `UPDATE articles

--- a/app/models.js
+++ b/app/models.js
@@ -65,7 +65,7 @@ const addComment = (comment, article_id) => {
 const updateVotes = (body, article_id) => {
     return fetchArticleById(article_id)
         .then(() => {
-            if (!body.inc_votes || Object.keys(body).length === 0 || typeof body.inc_votes !== "number") {
+            if (!body.inc_votes || Object.keys(body).length === 0) {
                 return Promise.reject({ status: 400, msg: "Bad request" })
             }
 

--- a/app/models.js
+++ b/app/models.js
@@ -65,20 +65,16 @@ const addComment = (comment, article_id) => {
 const updateVotes = (body, article_id) => {
     return fetchArticleById(article_id)
         .then(() => {
-            return db.query(`SELECT votes FROM articles WHERE article_id = $1`, [article_id])
-        })
-        .then(({ rows }) => {
             if (!body.inc_votes || typeof body.inc_votes !== "number") {
                 return Promise.reject({ status: 400, msg: "Bad request - body must have 'inc_votes' property of 'number' data type" })
             }
-            let newVoteTotal = rows[0].votes + body.inc_votes;
 
             let sqlUpdateVotesQuery = `UPDATE articles
-                                       SET votes = $1
+                                       SET votes = votes + $1
                                        WHERE article_id = $2
                                        RETURNING *`
 
-            return db.query(sqlUpdateVotesQuery, [newVoteTotal, article_id])
+            return db.query(sqlUpdateVotesQuery, [body.inc_votes, article_id])
         })
         .then(({ rows }) => {
             return rows[0];

--- a/app/models.js
+++ b/app/models.js
@@ -68,20 +68,24 @@ const addComment = (comment, article_id) => {
 }
 
 const updateVotes = (body, article_id) => {
-    return db.query(`SELECT votes FROM articles WHERE article_id = $1`, [article_id])
-       .then(({ rows }) => {
-           let newVoteTotal = rows[0].votes + body.inc_votes;
-       
-           let sqlUpdateVotesQuery = `UPDATE articles
+
+    return fetchArticleById(article_id)
+        .then(() => {
+            return db.query(`SELECT votes FROM articles WHERE article_id = $1`, [article_id])
+        })
+        .then(({ rows }) => {
+            let newVoteTotal = rows[0].votes + body.inc_votes;
+
+            let sqlUpdateVotesQuery = `UPDATE articles
                                        SET votes = $1
                                        WHERE article_id = $2
                                        RETURNING *`
-           
-           return db.query(sqlUpdateVotesQuery, [newVoteTotal, article_id])
-       })
-       .then(({ rows }) => {
-       return rows[0];
-   });
+
+            return db.query(sqlUpdateVotesQuery, [newVoteTotal, article_id])
+        })
+        .then(({ rows }) => {
+            return rows[0];
+        });
 };
 
 module.exports = { fetchTopics, fetchArticles, fetchArticleById, fetchCommentsById, addComment, updateVotes };

--- a/app/models.js
+++ b/app/models.js
@@ -46,13 +46,12 @@ const fetchCommentsById = (article_id) => {
 
 const addComment = (comment, article_id) => {
     return db.query(`SELECT * FROM articles WHERE article_id = $1`, [article_id])
-        .then(({ rows, rowCount }) => {
+        .then(({ rowCount }) => {
             if (rowCount === 0) {
                 return Promise.reject({ status: 404, msg: "Not found - no article of this ID in database" })
             }
             else {
-                const correctArticle = rows[0]
-                const formattedComment = [[comment.body, article_id, correctArticle.author]]
+                const formattedComment = [[comment.body, article_id, comment.username]]
 
                 let sqlAddCommentString = format(`INSERT INTO comments
                                     (body, article_id, author)

--- a/app/models.js
+++ b/app/models.js
@@ -45,30 +45,24 @@ const fetchCommentsById = (article_id) => {
 };
 
 const addComment = (comment, article_id) => {
-    return db.query(`SELECT * FROM articles WHERE article_id = $1`, [article_id])
-        .then(({ rowCount }) => {
-            if (rowCount === 0) {
-                return Promise.reject({ status: 404, msg: "Not found - no article of this ID in database" })
-            }
-            else {
-                const formattedComment = [[comment.body, article_id, comment.username]]
+    return fetchArticleById(article_id)
+        .then(() => {
+            const formattedComment = [[comment.body, article_id, comment.username]]
 
-                let sqlAddCommentString = format(`INSERT INTO comments
+            let sqlAddCommentString = format(`INSERT INTO comments
                                     (body, article_id, author)
                                     VALUES
                                     %L
                                     RETURNING *`, formattedComment)
 
-                return db.query(sqlAddCommentString)
-                    .then(({ rows }) => {
-                        return rows[0];
-                    });
-            }
+            return db.query(sqlAddCommentString)
+        })
+        .then(({ rows }) => {
+            return rows[0];
         });
-}
+};
 
 const updateVotes = (body, article_id) => {
-
     return fetchArticleById(article_id)
         .then(() => {
             return db.query(`SELECT votes FROM articles WHERE article_id = $1`, [article_id])

--- a/app/models.js
+++ b/app/models.js
@@ -65,7 +65,7 @@ const addComment = (comment, article_id) => {
 const updateVotes = (body, article_id) => {
     return fetchArticleById(article_id)
         .then(() => {
-            if (!body.inc_votes || typeof body.inc_votes !== "number") {
+            if (!body.inc_votes || Object.keys(body).length === 0 || typeof body.inc_votes !== "number") {
                 return Promise.reject({ status: 400, msg: "Bad request" })
             }
 


### PR DESCRIPTION
I am currently adding the error handler tests for non-existent or invalid (data type) article IDs into every endpoint that uses the article ID parametric endpoint... My thinking here is to test that I've remembered to use 'catch' in the controller for each endpoint, and that all the error handling functionality is connecting and working properly for that particular MVC combination, which is different for each endpoint. I am aware it makes my test suite code seem not-at-all DRY though, so please could I double check if this is necessary? Thank you :)